### PR TITLE
feat: implement front-end user login function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### pom flatten ###
+**/.flattened-pom.xml

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/annotation/FrontSaCheckLogin.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/annotation/FrontSaCheckLogin.java
@@ -1,0 +1,18 @@
+package com.hncboy.chatgpt.base.annotation;
+
+import cn.dev33.satoken.annotation.SaCheckLogin;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 前端用户登录校验注解
+ * @author CoDeleven
+ */
+@SaCheckLogin(type = "front")
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE})
+public @interface FrontSaCheckLogin {
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/config/EmailConfig.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/config/EmailConfig.java
@@ -1,0 +1,60 @@
+package com.hncboy.chatgpt.base.config;
+
+import cn.hutool.core.util.StrUtil;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * 邮箱参数配置
+ *
+ * @author CoDeleven
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "email")
+public class EmailConfig {
+    /**
+     * 邮箱服务器地址
+     */
+    private String host;
+    /**
+     * 邮箱服务器端口，默认25
+     */
+    private String port;
+    /**
+     * 发件邮箱地址
+     */
+    private String from;
+    /**
+     * 发件人名称
+     */
+    private String user;
+    /**
+     * 授权码
+     */
+    private String pass;
+    /**
+     * 是否需要授权
+     */
+    private Boolean auth;
+    /**
+     * 用于跳转验证的URL模板
+     */
+    private String verificationRedirectUrl;
+    /**
+     * 邮箱验证码过期时间，单位分钟。默认15分钟
+     */
+    private Integer verifyCodeExpireMinutes;
+
+    /**
+     * 用于判断邮箱服务是否可用，如果不可用，和邮箱相关的一些功能需要报错
+     *
+     * @return true有效；false无效
+     */
+    public boolean isAvailable() {
+        return StrUtil.isNotBlank(host) && StrUtil.isNotBlank(port) && StrUtil.isNotBlank(from)
+                && StrUtil.isNotBlank(user);
+    }
+
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/config/SaTokenConfig.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/config/SaTokenConfig.java
@@ -1,7 +1,10 @@
 package com.hncboy.chatgpt.base.config;
 
 import cn.dev33.satoken.interceptor.SaInterceptor;
+import cn.dev33.satoken.jwt.StpLogicJwtForStateless;
+import cn.dev33.satoken.stp.StpLogic;
 import cn.dev33.satoken.stp.StpUtil;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -22,5 +25,10 @@ public class SaTokenConfig implements WebMvcConfigurer {
                 .addPathPatterns("/admin/**")
                 // 放开管理端登录接口
                 .excludePathPatterns("/admin/sys_user/login");
+    }
+
+    @Bean
+    public StpLogic getStpLogicJwt() {
+        return new StpLogicJwtForStateless();
     }
 }

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/constant/ApplicationConstant.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/constant/ApplicationConstant.java
@@ -11,4 +11,16 @@ public interface ApplicationConstant {
      * ADMIN 路径前缀
      */
     String ADMIN_PATH_PREFIX = "admin";
+    /**
+     * 用户登录-JWT携带参数名称：注册类型code
+     */
+    String FRONT_JWT_REGISTER_TYPE_CODE = "registerTypeCode";
+    /**
+     * 用户登录-JWT携带参数名称：登录账号（邮箱/手机号）
+     */
+    String FRONT_JWT_USERNAME = "username";
+    /**
+     * 用户登录-JWT携带参数名称：基础用户ID
+     */
+    String FRONT_JWT_BASE_USER_ID = "baseUserId";
 }

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/domain/entity/EmailVerifyCodeDO.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/domain/entity/EmailVerifyCodeDO.java
@@ -1,0 +1,78 @@
+package com.hncboy.chatgpt.base.domain.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Date;
+
+import com.hncboy.chatgpt.base.enums.EmailBizTypeEnum;
+import lombok.Data;
+
+/**
+ * 邮箱验证码核销记录表，记录某个邮箱发送了什么验证码，方便验证
+ * @author CoDeleven
+ */
+@TableName(value ="email_verify_code")
+@Data
+public class EmailVerifyCodeDO implements Serializable {
+    /**
+     * 
+     */
+    @TableId(value = "id", type = IdType.AUTO)
+    private Integer id;
+
+    /**
+     * 验证码接收邮箱地址
+     */
+    @TableField(value = "to_email_address")
+    private String toEmailAddress;
+
+    /**
+     * 验证码
+     */
+    @TableField(value = "verify_code")
+    private String verifyCode;
+
+    /**
+     * 使用状态，0表示未使用，1表示已使用
+     */
+    @TableField(value = "status")
+    private Integer status;
+
+    /**
+     * 核销IP，方便识别一些机器人账号
+     */
+    @TableField(value = "verify_ip")
+    private String verifyIp;
+
+    /**
+     * 该条验证码何时过期，一般是发送时间+15分钟
+     */
+    @TableField(value = "expire_at")
+    private Date expireAt;
+
+    /**
+     * 当前邮箱业务
+     */
+    @TableField(value = "biz_type")
+    private EmailBizTypeEnum bizType;
+
+    /**
+     * 创建时间
+     */
+    @TableField(value = "create_time")
+    private Date createTime;
+
+    /**
+     * 更新时间
+     */
+    @TableField(value = "update_time")
+    private Date updateTime;
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/domain/entity/FrontUserBaseDO.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/domain/entity/FrontUserBaseDO.java
@@ -1,0 +1,60 @@
+package com.hncboy.chatgpt.base.domain.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 前端用户 基础表
+ *
+ * @author CoDeleven
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@TableName(value ="front_user_base")
+@Data
+public class FrontUserBaseDO implements Serializable {
+    @TableId(type = IdType.AUTO)
+    private Integer id;
+    /**
+     * 昵称
+     */
+    @TableField("nickname")
+    private String nickname;
+    /**
+     * 用户描述
+     */
+    @TableField("description")
+    private String description;
+    /**
+     * 头像版本
+     */
+    @TableField("avatar_version")
+    private Integer avatarVersion;
+    /**
+     * 最后一次登录IP
+     */
+    @TableField("last_login_ip")
+    private Integer lastLoginIp;
+    /**
+     * 创建时间
+     */
+    @TableField(value = "create_time", fill = FieldFill.INSERT)
+    private Date createTime;
+    /**
+     * 更新时间
+     */
+    @TableField(value = "update_time", fill = FieldFill.UPDATE)
+    private Date updateTime;
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/domain/entity/FrontUserExtraBindingDO.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/domain/entity/FrontUserExtraBindingDO.java
@@ -1,0 +1,60 @@
+package com.hncboy.chatgpt.base.domain.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Date;
+
+import com.hncboy.chatgpt.base.enums.UserExtraBindingTypeEnum;
+import lombok.Data;
+
+/**
+ * 前端用户绑定表
+ * @author CoDeleven
+ */
+@TableName(value ="front_user_extra_binding")
+@Data
+public class FrontUserExtraBindingDO implements Serializable {
+    /**
+     * 
+     */
+    @TableId(value = "id", type = IdType.AUTO)
+    private Integer id;
+
+    /**
+     * 绑定类型,qq,wechat,sina,github,email,phone
+     */
+    @TableField(value = "binding_type")
+    private UserExtraBindingTypeEnum bindingType;
+
+    /**
+     * 额外信息表的用户ID
+     */
+    @TableField(value = "extra_info_id")
+    private Integer extraInfoId;
+
+    /**
+     * 基础用户表的ID
+     */
+    @TableField(value = "base_user_id")
+    private Integer baseUserId;
+
+    /**
+     * 
+     */
+    @TableField(value = "create_time")
+    private Date createTime;
+
+    /**
+     * 
+     */
+    @TableField(value = "update_time")
+    private Date updateTime;
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/domain/entity/FrontUserExtraEmailDO.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/domain/entity/FrontUserExtraEmailDO.java
@@ -1,0 +1,71 @@
+package com.hncboy.chatgpt.base.domain.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 前端用户邮箱登录
+ * @author CoDeleven
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@TableName(value ="front_user_extra_email")
+@Data
+public class FrontUserExtraEmailDO implements Serializable {
+    /**
+     * 
+     */
+    @TableId(value = "id", type = IdType.AUTO)
+    private Integer id;
+
+    /**
+     * 邮箱账号
+     */
+    @TableField(value = "username")
+    private String username;
+
+    /**
+     * 加密后的密码
+     */
+    @TableField(value = "password")
+    private String password;
+
+    /**
+     * 加密盐
+     */
+    @TableField(value = "salt")
+    private String salt;
+
+    /**
+     * 是否验证过
+     */
+    @TableField(value = "verified")
+    private Boolean verified;
+
+    /**
+     * 创建时间
+     */
+    @TableField(value = "create_time")
+    private Date createTime;
+
+    /**
+     * 更新时间
+     */
+    @TableField(value = "update_time")
+    private Date updateTime;
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/domain/entity/SysEmailSendLogDO.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/domain/entity/SysEmailSendLogDO.java
@@ -1,0 +1,90 @@
+package com.hncboy.chatgpt.base.domain.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Date;
+
+import com.hncboy.chatgpt.base.enums.EmailBizTypeEnum;
+import lombok.Data;
+
+/**
+ * 邮箱发送日志
+ * @author CoDeleven
+ */
+@TableName(value ="sys_email_send_log")
+@Data
+public class SysEmailSendLogDO implements Serializable {
+    /**
+     * 
+     */
+    @TableId(value = "id", type = IdType.AUTO)
+    private Long id;
+
+    /**
+     * 发件人
+     */
+    @TableField(value = "from_email_address")
+    private String fromEmailAddress;
+
+    /**
+     * 收件人
+     */
+    @TableField(value = "to_email_address")
+    private String toEmailAddress;
+
+    /**
+     * 业务类型
+     */
+    @TableField(value = "biz_type")
+    private EmailBizTypeEnum bizType;
+
+    /**
+     * 发送内容
+     */
+    @TableField(value = "content")
+    private String content;
+
+    /**
+     * 发送状态，0成功，1失败
+     */
+    @TableField(value = "status")
+    private Integer status;
+
+    /**
+     * 发送内容
+     */
+    @TableField(value = "message_id")
+    private String messageId;
+
+    /**
+     * 发送后的消息，用于记录成功/失败的信息，成功默认为success
+     */
+    @TableField(value = "message")
+    private String message;
+
+    /**
+     * 创建时间
+     */
+    @TableField(value = "create_time")
+    private Date createTime;
+
+    /**
+     * 
+     */
+    @TableField(value = "update_time")
+    private Date updateTime;
+
+    /**
+     * 操作人用户ID，预留字段，默认为1
+     */
+    @TableField(value = "operator_sys_user_id")
+    private Integer operatorSysUserId;
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/domain/entity/SysFrontUserLoginLogDO.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/domain/entity/SysFrontUserLoginLogDO.java
@@ -1,0 +1,72 @@
+package com.hncboy.chatgpt.base.domain.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableField;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Date;
+
+import com.hncboy.chatgpt.base.enums.FrontUserRegisterTypeEnum;
+import lombok.Data;
+
+/**
+ * 前端用户登录日志表
+ * @author CoDeleven
+ */
+@TableName(value ="sys_front_user_login_log")
+@Data
+public class SysFrontUserLoginLogDO implements Serializable {
+    /**
+     * 
+     */
+    @TableId(value = "id", type = IdType.AUTO)
+    private Integer id;
+
+    /**
+     * 登录的基础用户ID
+     */
+    @TableField(value = "base_user_id")
+    private Integer baseUserId;
+
+    /**
+     * 登录方式（注册方式），邮箱登录，手机登录等等
+     */
+    @TableField(value = "login_type")
+    private FrontUserRegisterTypeEnum loginType;
+
+    /**
+     * 登录信息ID与login_type有关联，邮箱登录时关联front_user_extra_email
+     */
+    @TableField(value = "login_extra_info_id")
+    private Integer loginExtraInfoId;
+
+    /**
+     * 登录的IP地址
+     */
+    @TableField(value = "login_ip")
+    private String loginIp;
+
+    /**
+     * 登录状态，1登录成功，0登录失败
+     */
+    @TableField(value = "login_status")
+    private Boolean loginStatus;
+
+    /**
+     * 登录后返回的消息
+     */
+    @TableField(value = "message")
+    private String message;
+
+    /**
+     * 发生时间
+     */
+    @TableField(value = "create_time")
+    private Date createTime;
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/enums/EmailBizTypeEnum.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/enums/EmailBizTypeEnum.java
@@ -1,0 +1,29 @@
+package com.hncboy.chatgpt.base.enums;
+
+import com.baomidou.mybatisplus.annotation.EnumValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 邮箱业务用途枚举，注册、找回密码、金额不足通知？
+ *
+ * @author CoDeleven
+ */
+@AllArgsConstructor
+public enum EmailBizTypeEnum {
+    /**
+     * 用户注册验证码认证
+     */
+    REGISTER_VERIFY(10, "注册认证"),
+    /**
+     * 用户找回密码验证码认证
+     */
+    RETRIEVE_PASSWORD(11, "找回密码认证");
+
+    @Getter
+    @EnumValue
+    private final Integer code;
+
+    @Getter
+    private final String desc;
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/enums/FrontUserRegisterTypeEnum.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/enums/FrontUserRegisterTypeEnum.java
@@ -1,0 +1,44 @@
+package com.hncboy.chatgpt.base.enums;
+
+import com.baomidou.mybatisplus.annotation.EnumValue;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Objects;
+
+/**
+ * 前端用户注册类型
+ *
+ * @author CoDeleven
+ */
+@Getter
+@AllArgsConstructor
+public enum FrontUserRegisterTypeEnum {
+    EMAIL("email", "邮箱"),
+
+    PHONE("phone", "手机号")
+    ;
+
+    @Getter
+    @EnumValue
+    @JsonValue
+    private final String code;
+
+    @Getter
+    private final String desc;
+
+    /**
+     * 根据code获取注册枚举类型
+     * @param registerTypeCode 注册代码
+     * @return 枚举类型
+     */
+    public static FrontUserRegisterTypeEnum getByCode(String registerTypeCode) {
+        for (FrontUserRegisterTypeEnum type : FrontUserRegisterTypeEnum.values()) {
+            if(Objects.equals(type.getCode(), registerTypeCode)) {
+                return type;
+            }
+        }
+        return null;
+    }
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/enums/UserExtraBindingTypeEnum.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/enums/UserExtraBindingTypeEnum.java
@@ -1,0 +1,21 @@
+package com.hncboy.chatgpt.base.enums;
+
+import com.baomidou.mybatisplus.annotation.EnumValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 用户绑定类型枚举
+ *
+ * @author CoDeleven
+ */
+@AllArgsConstructor
+@Getter
+public enum UserExtraBindingTypeEnum {
+    BIND_EMAIL("email", "邮箱绑定");
+
+    @EnumValue
+    private final String code;
+    private final String desc;
+
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/mapper/EmailVerifyCodeMapper.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/mapper/EmailVerifyCodeMapper.java
@@ -1,0 +1,16 @@
+package com.hncboy.chatgpt.base.mapper;
+
+import com.hncboy.chatgpt.base.domain.entity.EmailVerifyCodeDO;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+/**
+ * 针对表【email_verify_code(邮箱验证码核销记录表，记录某个邮箱发送了什么验证码，方便验证)】的数据库操作Mapper
+* @author CoDeleven
+*/
+public interface EmailVerifyCodeMapper extends BaseMapper<EmailVerifyCodeDO> {
+
+}
+
+
+
+

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/mapper/FrontUserBaseMapper.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/mapper/FrontUserBaseMapper.java
@@ -1,0 +1,13 @@
+package com.hncboy.chatgpt.base.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserBaseDO;
+
+/**
+ * 前端基础用户
+ *
+ * @author CoDeleven
+ * @date 2023.4.8
+ */
+public interface FrontUserBaseMapper extends BaseMapper<FrontUserBaseDO> {
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/mapper/FrontUserExtraBindingMapper.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/mapper/FrontUserExtraBindingMapper.java
@@ -1,0 +1,18 @@
+package com.hncboy.chatgpt.base.mapper;
+
+import com.hncboy.chatgpt.base.domain.entity.FrontUserExtraBindingDO;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+/**
+* @author codel
+* @description 针对表【front_user_extra_binding(前端用户绑定表)】的数据库操作Mapper
+* @createDate 2023-04-08 16:48:31
+* @Entity com.hncboy.chatgpt.base.domain.entity.FrontUserExtraBindingDO
+*/
+public interface FrontUserExtraBindingMapper extends BaseMapper<FrontUserExtraBindingDO> {
+
+}
+
+
+
+

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/mapper/FrontUserExtraEmailMapper.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/mapper/FrontUserExtraEmailMapper.java
@@ -1,0 +1,18 @@
+package com.hncboy.chatgpt.base.mapper;
+
+import com.hncboy.chatgpt.base.domain.entity.FrontUserExtraEmailDO;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+/**
+* @author CoDeleven
+* @description 针对表【front_user_extra_email(前端用户邮箱登录)】的数据库操作Mapper
+* @createDate 2023-04-08 16:46:30
+* @Entity com.hncboy.chatgpt.base.domain.entity.FrontUserExtraEmailDO
+*/
+public interface FrontUserExtraEmailMapper extends BaseMapper<FrontUserExtraEmailDO> {
+
+}
+
+
+
+

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/mapper/SysEmailSendLogMapper.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/mapper/SysEmailSendLogMapper.java
@@ -1,0 +1,16 @@
+package com.hncboy.chatgpt.base.mapper;
+
+import com.hncboy.chatgpt.base.domain.entity.SysEmailSendLogDO;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+/**
+ * 针对表【sys_email_send_log(邮箱发送日志)】的数据库操作Mapper
+* @author CoDeleven
+*/
+public interface SysEmailSendLogMapper extends BaseMapper<SysEmailSendLogDO> {
+
+}
+
+
+
+

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/mapper/SysFrontUserLoginLogMapper.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/mapper/SysFrontUserLoginLogMapper.java
@@ -1,0 +1,16 @@
+package com.hncboy.chatgpt.base.mapper;
+
+import com.hncboy.chatgpt.base.domain.entity.SysFrontUserLoginLogDO;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+
+/**
+ * 针对表【sys_front_user_login_log(前端用户登录日志表)】的数据库操作Mapper
+* @author CoDeleven
+*/
+public interface SysFrontUserLoginLogMapper extends BaseMapper<SysFrontUserLoginLogDO> {
+
+}
+
+
+
+

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/EmailService.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/EmailService.java
@@ -1,0 +1,18 @@
+package com.hncboy.chatgpt.base.service;
+
+/**
+ * 邮箱服务
+ *
+ * @author CoDeleven
+ */
+public interface EmailService {
+    /**
+     * 发送邮箱验证码到目标邮箱里去
+     *
+     * @param targetEmail 目标邮箱
+     * @param verifyCode 验证码
+     * @return 发送结果
+     */
+    void sendForVerifyCode(String targetEmail, String verifyCode);
+
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/EmailVerifyCodeService.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/EmailVerifyCodeService.java
@@ -1,0 +1,29 @@
+package com.hncboy.chatgpt.base.service;
+
+import com.hncboy.chatgpt.base.domain.entity.EmailVerifyCodeDO;
+import com.baomidou.mybatisplus.extension.service.IService;
+import com.hncboy.chatgpt.base.enums.EmailBizTypeEnum;
+
+/**
+ * 针对表【email_verify_code(邮箱验证码核销记录表，记录某个邮箱发送了什么验证码，方便验证)】的数据库操作Service
+* @author CoDeleven
+*/
+public interface EmailVerifyCodeService extends IService<EmailVerifyCodeDO> {
+
+    EmailVerifyCodeDO createVerifyCode(EmailBizTypeEnum registerVerify, String identity);
+
+    /**
+     * 根据验证码查找一个有效（未过期，未验证）的验证记录
+     *
+     * @param verifyCode 验证码
+     * @return 验证记录
+     */
+    EmailVerifyCodeDO findAvailableByVerifyCode(String verifyCode);
+
+    /**
+     * 完成验证记录
+     *
+     * @param availableVerifyCode 待完成的验证记录
+     */
+    void verifySuccess(EmailVerifyCodeDO availableVerifyCode);
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/FrontUserBaseService.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/FrontUserBaseService.java
@@ -1,0 +1,19 @@
+package com.hncboy.chatgpt.base.service;
+
+import com.baomidou.mybatisplus.extension.service.IService;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserBaseDO;
+
+/**
+ * 前端用户基础用户，后续的服务都使用这张表的ID
+ *
+ * @author CoDeleven
+ */
+public interface FrontUserBaseService extends IService<FrontUserBaseDO> {
+
+    /**
+     * 创建一个空的基础用户信息
+     */
+    FrontUserBaseDO createEmptyBaseUser();
+
+    FrontUserBaseDO findUserInfoById(Integer baseUserId);
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/FrontUserExtraBindingService.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/FrontUserExtraBindingService.java
@@ -1,0 +1,18 @@
+package com.hncboy.chatgpt.base.service;
+
+import com.hncboy.chatgpt.base.domain.entity.FrontUserBaseDO;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserExtraBindingDO;
+import com.baomidou.mybatisplus.extension.service.IService;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserExtraEmailDO;
+import com.hncboy.chatgpt.base.enums.FrontUserRegisterTypeEnum;
+
+/**
+ * 针对表【front_user_extra_binding(前端用户绑定表)】的数据库操作Service
+* @author CoDeleven
+*/
+public interface FrontUserExtraBindingService extends IService<FrontUserExtraBindingDO> {
+
+    void bindEmail(FrontUserBaseDO baseUser, FrontUserExtraEmailDO emailInfo);
+
+    FrontUserExtraBindingDO findBindingRelations(FrontUserRegisterTypeEnum frontUserRegisterTypeEnum, Integer extraInfoId);
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/FrontUserExtraEmailService.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/FrontUserExtraEmailService.java
@@ -1,0 +1,24 @@
+package com.hncboy.chatgpt.base.service;
+
+import com.baomidou.mybatisplus.extension.service.IService;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserExtraEmailDO;
+
+/**
+ * 使用邮箱登录的前端用户服务
+ *
+ * @author CoDeleven
+ */
+public interface FrontUserExtraEmailService extends IService<FrontUserExtraEmailDO> {
+
+    /**
+     * 是否已使用
+     *
+     * @param username 用户名，邮箱方式下是邮箱，手机方式下是手机号码
+     * @return 是否已使用，true已使用；false未使用
+     */
+    boolean isUsed(String username);
+
+    FrontUserExtraEmailDO getUnverifiedEmailAccount(String identity);
+
+    FrontUserExtraEmailDO getEmailAccount(String username);
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/SysEmailSendLogService.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/SysEmailSendLogService.java
@@ -1,0 +1,33 @@
+package com.hncboy.chatgpt.base.service;
+
+import com.hncboy.chatgpt.base.domain.entity.SysEmailSendLogDO;
+import com.baomidou.mybatisplus.extension.service.IService;
+import com.hncboy.chatgpt.base.enums.EmailBizTypeEnum;
+
+/**
+ * 针对表【sys_email_send_log(邮箱发送日志)】的数据库操作Service
+* @author CoDeleven
+*/
+public interface SysEmailSendLogService extends IService<SysEmailSendLogDO> {
+    /**
+     * 创建邮件发送成功的日志
+     *
+     * @param messageId 邮件msgId
+     * @param from 发件人地址
+     * @param to 收件人地址
+     * @param bizType 业务类型
+     * @param content 发送内容
+     */
+    void createSuccessLogBySysLog(String messageId, String from, String to, EmailBizTypeEnum bizType, String content);
+
+    /**
+     * 创建邮件发送失败的日志
+     *
+     * @param messageId 邮件msgId
+     * @param from 发件人地址
+     * @param to 收件人地址
+     * @param bizType 业务类型
+     * @param content 发送内容
+     */
+    void createFailedLogBySysLog(String messageId, String from, String to, EmailBizTypeEnum bizType, String content, String failedMsg);
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/SysFrontUserLoginLogService.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/SysFrontUserLoginLogService.java
@@ -1,0 +1,30 @@
+package com.hncboy.chatgpt.base.service;
+
+import com.hncboy.chatgpt.base.domain.entity.SysFrontUserLoginLogDO;
+import com.baomidou.mybatisplus.extension.service.IService;
+import com.hncboy.chatgpt.base.enums.FrontUserRegisterTypeEnum;
+
+/**
+ * 针对表【sys_front_user_login_log(前端用户登录日志表)】的数据库操作Service
+* @author CoDeleven
+*/
+public interface SysFrontUserLoginLogService extends IService<SysFrontUserLoginLogDO> {
+    /**
+     * 登录失败记录表
+     *
+     * @param registerType 注册类型
+     * @param extraInfoId 登录信息表ID
+     * @param baseUserId 基础用户ID
+     * @param message 失败原因
+     */
+    void loginFailed(FrontUserRegisterTypeEnum registerType, Integer extraInfoId, Integer baseUserId, String message);
+
+    /**
+     * 登录成功记录表
+     *
+     * @param registerType 注册类型
+     * @param extraInfoId 登录信息表ID
+     * @param baseUserId 基础用户ID
+     */
+    void loginSuccess(FrontUserRegisterTypeEnum registerType, Integer extraInfoId, Integer baseUserId);
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/EmailServiceImpl.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/EmailServiceImpl.java
@@ -1,0 +1,58 @@
+package com.hncboy.chatgpt.base.service.impl;
+
+import cn.hutool.core.net.url.UrlBuilder;
+import cn.hutool.extra.mail.MailAccount;
+import cn.hutool.extra.mail.MailUtil;
+import com.hncboy.chatgpt.base.config.EmailConfig;
+import com.hncboy.chatgpt.base.enums.EmailBizTypeEnum;
+import com.hncboy.chatgpt.base.service.EmailService;
+import com.hncboy.chatgpt.base.service.SysEmailSendLogService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 邮箱注册类型策略实现类
+ *
+ * @author CoDeleven
+ */
+@Slf4j
+@Service
+public class EmailServiceImpl implements EmailService {
+    private final EmailConfig emailConfig;
+    private final MailAccount mailAccount;
+    private final SysEmailSendLogService emailLogService;
+
+    public EmailServiceImpl(EmailConfig emailConfig, SysEmailSendLogService emailLogService) {
+        this.emailConfig = emailConfig;
+        this.emailLogService = emailLogService;
+
+        mailAccount = new MailAccount();
+        mailAccount.setHost(emailConfig.getHost());
+        mailAccount.setPort(Integer.parseInt(emailConfig.getPort()));
+        mailAccount.setFrom(emailConfig.getFrom());
+        mailAccount.setUser(emailConfig.getUser());
+        mailAccount.setAuth(emailConfig.getAuth());
+        mailAccount.setDebug(true);
+        mailAccount.setSslEnable(true);
+        mailAccount.setPass(emailConfig.getPass());
+        log.info("初始化邮箱账号完毕，配置信息为：{} ", emailConfig);
+    }
+
+    @Override
+    public void sendForVerifyCode(String targetEmail, String verifyCode) {
+        String url = UrlBuilder.of(emailConfig.getVerificationRedirectUrl()).addQuery("verifyCode", verifyCode).build();
+        String content = "点击下面的网址完成【StarGPT】账号的注册：" + url;
+
+        // 记录日志
+        try {
+            String sendMsgId = this.sendMessage(targetEmail, url);
+            emailLogService.createSuccessLogBySysLog(sendMsgId, mailAccount.getFrom(), targetEmail, EmailBizTypeEnum.REGISTER_VERIFY, content);
+        }catch (Exception e) {
+            emailLogService.createFailedLogBySysLog("", mailAccount.getFrom(), targetEmail, EmailBizTypeEnum.REGISTER_VERIFY, content, e.getMessage());
+        }
+    }
+
+    protected String sendMessage(String targetEmail, String content) {
+        return MailUtil.send(mailAccount, targetEmail, "【StarGPT】账号注册", content, false);
+    }
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/EmailVerifyCodeServiceImpl.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/EmailVerifyCodeServiceImpl.java
@@ -1,0 +1,58 @@
+package com.hncboy.chatgpt.base.service.impl;
+
+import cn.hutool.core.date.DateUtil;
+import cn.hutool.core.util.RandomUtil;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.hncboy.chatgpt.base.config.EmailConfig;
+import com.hncboy.chatgpt.base.domain.entity.EmailVerifyCodeDO;
+import com.hncboy.chatgpt.base.service.EmailVerifyCodeService;
+import com.hncboy.chatgpt.base.mapper.EmailVerifyCodeMapper;
+import com.hncboy.chatgpt.base.enums.EmailBizTypeEnum;
+import com.hncboy.chatgpt.base.util.WebUtil;
+import jakarta.annotation.Resource;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+/**
+ * 针对表【email_verify_code(邮箱验证码核销记录表，记录某个邮箱发送了什么验证码，方便验证)】的数据库操作Service实现
+* @author CoDeleven
+*/
+@Service
+public class EmailVerifyCodeServiceImpl extends ServiceImpl<EmailVerifyCodeMapper, EmailVerifyCodeDO>
+    implements EmailVerifyCodeService{
+
+    @Resource
+    private EmailConfig emailConfig;
+
+    @Override
+    public EmailVerifyCodeDO createVerifyCode(EmailBizTypeEnum bizType, String identity) {
+        EmailVerifyCodeDO verifyCode = new EmailVerifyCodeDO();
+        verifyCode.setVerifyCode(RandomUtil.randomString(32));
+        verifyCode.setStatus(0);
+        verifyCode.setVerifyIp(WebUtil.getIp());
+        verifyCode.setBizType(bizType);
+        verifyCode.setToEmailAddress(identity);
+        verifyCode.setExpireAt(DateUtil.offsetMinute(new Date(), emailConfig.getVerifyCodeExpireMinutes()));
+        this.save(verifyCode);
+        return verifyCode;
+    }
+
+    @Override
+    public EmailVerifyCodeDO findAvailableByVerifyCode(String verifyCode) {
+        return this.getOne(new QueryWrapper<EmailVerifyCodeDO>().eq("verify_code", verifyCode)
+                .eq("status", 0).gt("expire_at", new Date()));
+    }
+
+    @Override
+    public void verifySuccess(EmailVerifyCodeDO availableVerifyCode) {
+        availableVerifyCode.setVerifyIp(WebUtil.getIp());
+        availableVerifyCode.setStatus(1);
+        this.updateById(availableVerifyCode);
+    }
+}
+
+
+
+

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/FrontUserBaseServiceImpl.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/FrontUserBaseServiceImpl.java
@@ -1,0 +1,37 @@
+package com.hncboy.chatgpt.base.service.impl;
+
+import cn.hutool.core.util.RandomUtil;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserBaseDO;
+import com.hncboy.chatgpt.base.mapper.FrontUserBaseMapper;
+import com.hncboy.chatgpt.base.service.FrontUserBaseService;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+/**
+ * 基础用户服务实现类
+ * @author CoDeleven
+ */
+@Service
+public class FrontUserBaseServiceImpl extends ServiceImpl<FrontUserBaseMapper, FrontUserBaseDO> implements FrontUserBaseService {
+
+    @Override
+    public FrontUserBaseDO createEmptyBaseUser() {
+        FrontUserBaseDO userBaseDO = new FrontUserBaseDO();
+        userBaseDO.setNickname("StarGPT_" + RandomUtil.randomString(6));
+        userBaseDO.setCreateTime(new Date());
+        userBaseDO.setUpdateTime(new Date());
+        userBaseDO.setLastLoginIp(null);
+        userBaseDO.setDescription(null);
+        userBaseDO.setAvatarVersion(0);
+        this.save(userBaseDO);
+        return userBaseDO;
+    }
+
+    @Override
+    public FrontUserBaseDO findUserInfoById(Integer baseUserId) {
+        return this.getOne(new QueryWrapper<FrontUserBaseDO>().eq("id", baseUserId));
+    }
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/FrontUserExtraBindingServiceImpl.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/FrontUserExtraBindingServiceImpl.java
@@ -1,0 +1,42 @@
+package com.hncboy.chatgpt.base.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserBaseDO;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserExtraBindingDO;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserExtraEmailDO;
+import com.hncboy.chatgpt.base.enums.FrontUserRegisterTypeEnum;
+import com.hncboy.chatgpt.base.enums.UserExtraBindingTypeEnum;
+import com.hncboy.chatgpt.base.service.FrontUserExtraBindingService;
+import com.hncboy.chatgpt.base.mapper.FrontUserExtraBindingMapper;
+import org.springframework.stereotype.Service;
+
+/**
+ * 针对表【front_user_extra_binding(前端用户绑定表)】的数据库操作Service实现
+* @author CoDeleven
+*/
+@Service
+public class FrontUserExtraBindingServiceImpl extends ServiceImpl<FrontUserExtraBindingMapper, FrontUserExtraBindingDO>
+    implements FrontUserExtraBindingService{
+
+    @Override
+    public void bindEmail(FrontUserBaseDO baseUser, FrontUserExtraEmailDO emailInfo) {
+        FrontUserExtraBindingDO bindingDO = new FrontUserExtraBindingDO();
+        bindingDO.setBindingType(UserExtraBindingTypeEnum.BIND_EMAIL);
+        bindingDO.setExtraInfoId(emailInfo.getId());
+        bindingDO.setBaseUserId(baseUser.getId());
+        this.save(bindingDO);
+    }
+
+    @Override
+    public FrontUserExtraBindingDO findBindingRelations(FrontUserRegisterTypeEnum registerType,
+                                                        Integer extraInfoId) {
+        return this.getOne(new QueryWrapper<FrontUserExtraBindingDO>()
+                .eq("binding_type", registerType.getCode())
+                .eq("extra_info_id", extraInfoId));
+    }
+}
+
+
+
+

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/FrontUserExtraEmailServiceImpl.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/FrontUserExtraEmailServiceImpl.java
@@ -1,0 +1,43 @@
+package com.hncboy.chatgpt.base.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserExtraEmailDO;
+import com.hncboy.chatgpt.base.mapper.FrontUserExtraEmailMapper;
+import com.hncboy.chatgpt.base.service.FrontUserExtraEmailService;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+/**
+ * 通用的前端用户邮箱登录方式服务
+ *
+ * @author CoDeleven
+ */
+@Service("CommonFrontUserExtraEmailServiceImpl")
+public class FrontUserExtraEmailServiceImpl extends ServiceImpl<FrontUserExtraEmailMapper, FrontUserExtraEmailDO>
+        implements FrontUserExtraEmailService {
+
+    @Override
+    public boolean isUsed(String username) {
+        FrontUserExtraEmailDO userExtraEmail = this.getOne(new LambdaQueryWrapper<FrontUserExtraEmailDO>()
+                .select(FrontUserExtraEmailDO::getVerified, FrontUserExtraEmailDO::getId)
+                .eq(FrontUserExtraEmailDO::getUsername, username));
+        if(Objects.isNull(userExtraEmail)) {
+            return false;
+        }
+        return userExtraEmail.getVerified();
+    }
+
+    @Override
+    public FrontUserExtraEmailDO getUnverifiedEmailAccount(String identity) {
+        return this.getOne(new LambdaQueryWrapper<FrontUserExtraEmailDO>()
+                .eq(FrontUserExtraEmailDO::getUsername, identity).eq(FrontUserExtraEmailDO::getVerified, false));
+    }
+
+    @Override
+    public FrontUserExtraEmailDO getEmailAccount(String username) {
+        return this.getOne(new LambdaQueryWrapper<FrontUserExtraEmailDO>()
+                .eq(FrontUserExtraEmailDO::getUsername, username));
+    }
+}

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/SysEmailSendLogServiceImpl.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/SysEmailSendLogServiceImpl.java
@@ -1,0 +1,59 @@
+package com.hncboy.chatgpt.base.service.impl;
+
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.hncboy.chatgpt.base.domain.entity.SysEmailSendLogDO;
+import com.hncboy.chatgpt.base.enums.EmailBizTypeEnum;
+import com.hncboy.chatgpt.base.service.SysEmailSendLogService;
+import com.hncboy.chatgpt.base.mapper.SysEmailSendLogMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+/**
+ * 针对表【sys_email_send_log(邮箱发送日志)】的数据库操作Service实现
+* @author CoDeleven
+*/
+@Service
+public class SysEmailSendLogServiceImpl extends ServiceImpl<SysEmailSendLogMapper, SysEmailSendLogDO>
+    implements SysEmailSendLogService{
+
+    /**
+     * 邮件发送成功的默认消息
+     */
+    private static final String DEFAULT_SEND_SUCCESS_MESSAGE = "success";
+    private static final int STATUS_SEND_SUCCESS = 1;
+    private static final int STATUS_SEND_FAILED = 0;
+    @Override
+    public void createSuccessLogBySysLog(String messageId, String from, String to, EmailBizTypeEnum bizType, String content) {
+        SysEmailSendLogDO log = this.createLogBySysLog(messageId, from, to, bizType, content);
+        log.setStatus(STATUS_SEND_SUCCESS);
+        log.setMessage(DEFAULT_SEND_SUCCESS_MESSAGE);
+        this.save(log);
+    }
+
+    @Override
+    public void createFailedLogBySysLog(String messageId, String from, String to, EmailBizTypeEnum bizType, String content, String failedMsg) {
+        SysEmailSendLogDO log = this.createLogBySysLog(messageId, from, to, bizType, content);
+        log.setStatus(STATUS_SEND_FAILED);
+        log.setMessage(failedMsg);
+        this.save(log);
+    }
+
+    private SysEmailSendLogDO createLogBySysLog(String messageId, String from, String to, EmailBizTypeEnum bizType, String content) {
+        SysEmailSendLogDO sendLog = new SysEmailSendLogDO();
+        sendLog.setFromEmailAddress(from);
+        sendLog.setToEmailAddress(to);
+        sendLog.setContent(content);
+        sendLog.setBizType(bizType);
+        sendLog.setMessageId(messageId);
+        // 预留字段
+        sendLog.setOperatorSysUserId(1);
+        sendLog.setCreateTime(new Date());
+        sendLog.setUpdateTime(new Date());
+        return sendLog;
+    }
+}
+
+
+
+

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/SysFrontUserLoginLogServiceImpl.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/service/impl/SysFrontUserLoginLogServiceImpl.java
@@ -1,0 +1,46 @@
+package com.hncboy.chatgpt.base.service.impl;
+
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.hncboy.chatgpt.base.domain.entity.SysFrontUserLoginLogDO;
+import com.hncboy.chatgpt.base.enums.FrontUserRegisterTypeEnum;
+import com.hncboy.chatgpt.base.service.SysFrontUserLoginLogService;
+import com.hncboy.chatgpt.base.mapper.SysFrontUserLoginLogMapper;
+import com.hncboy.chatgpt.base.util.WebUtil;
+import org.springframework.stereotype.Service;
+
+/**
+ * 针对表【sys_front_user_login_log(前端用户登录日志表)】的数据库操作Service实现
+* @author CoDeleven
+*/
+@Service
+public class SysFrontUserLoginLogServiceImpl extends ServiceImpl<SysFrontUserLoginLogMapper, SysFrontUserLoginLogDO>
+    implements SysFrontUserLoginLogService{
+
+    @Override
+    public void loginFailed(FrontUserRegisterTypeEnum registerType, Integer extraInfoId, Integer baseUserId, String message) {
+        SysFrontUserLoginLogDO logDO = new SysFrontUserLoginLogDO();
+        logDO.setBaseUserId(baseUserId);
+        logDO.setLoginExtraInfoId(extraInfoId);
+        logDO.setLoginStatus(false);
+        logDO.setLoginType(registerType);
+        logDO.setMessage(message);
+        logDO.setLoginIp(WebUtil.getIp());
+        this.save(logDO);
+    }
+
+    @Override
+    public void loginSuccess(FrontUserRegisterTypeEnum registerType, Integer extraInfoId, Integer baseUserId) {
+        SysFrontUserLoginLogDO logDO = new SysFrontUserLoginLogDO();
+        logDO.setBaseUserId(baseUserId);
+        logDO.setLoginExtraInfoId(extraInfoId);
+        logDO.setLoginStatus(true);
+        logDO.setLoginType(registerType);
+        logDO.setMessage("success");
+        logDO.setLoginIp(WebUtil.getIp());
+        this.save(logDO);
+    }
+}
+
+
+
+

--- a/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/util/SimpleCaptchaUtil.java
+++ b/chatgpt-base/src/main/java/com/hncboy/chatgpt/base/util/SimpleCaptchaUtil.java
@@ -1,0 +1,76 @@
+package com.hncboy.chatgpt.base.util;
+
+import cn.hutool.cache.Cache;
+import cn.hutool.cache.CacheUtil;
+import cn.hutool.captcha.CaptchaUtil;
+import cn.hutool.captcha.CircleCaptcha;
+import cn.hutool.captcha.LineCaptcha;
+import cn.hutool.captcha.ShearCaptcha;
+import cn.hutool.captcha.generator.CodeGenerator;
+import cn.hutool.core.lang.func.Func0;
+import cn.hutool.core.util.RandomUtil;
+import lombok.experimental.UtilityClass;
+
+import java.util.Objects;
+
+/**
+ * 简易图形验证码工具
+ *
+ * @author CoDeleven
+ */
+@UtilityClass
+public class SimpleCaptchaUtil {
+    // 建立 picCodeSessionId 和 Captcha 的关系，缓存时间180秒
+    private final static Cache<String, LineCaptcha> CAPTCHA_CACHE = CacheUtil.newTimedCache(180_000);
+
+    /**
+     * 获取验证码图片Base64，并存储 token 和 验证码关系
+     *
+     * @param picCodeSessionId 图片会话，用来比对当前验证码属于哪一次请求
+     * @return 图片Base64
+     */
+    public String getBase64Captcha(String picCodeSessionId) {
+        // 每次获取时，建立 picCodeToken <-> captcha 的关系
+        LineCaptcha captcha = generateCaptchaObject();
+        CAPTCHA_CACHE.put(picCodeSessionId, captcha);
+        return captcha.getImageBase64();
+    }
+
+    /**
+     * 验证图形验证码是否正确
+     *
+     * @param picCodeSessionId 图片会话，用来比对当前验证码属于哪一次请求
+     * @param userInputCode 用户输入的验证码
+     * @return true，用户输入的正确；false，用户输入的错误
+     */
+    public boolean verifyCaptcha(String picCodeSessionId, String userInputCode) {
+        LineCaptcha captcha = CAPTCHA_CACHE.get(picCodeSessionId);
+        if(Objects.isNull(captcha)) {
+            return false;
+        }
+        return captcha.verify(userInputCode);
+    }
+
+    /**
+     * 生成验证码对象
+     * ！挺费内存的，因为每次产生code，图片数据都还存在！
+     *
+     * @return ShearCaptcha用于生成验证码
+     */
+    public static LineCaptcha generateCaptchaObject() {
+        LineCaptcha captcha = CaptchaUtil.createLineCaptcha(250, 100, 6, 32);
+        // 设置生成方式
+        captcha.setGenerator(new CodeGenerator() {
+            @Override
+            public String generate() {
+                return RandomUtil.randomString(6);
+            }
+
+            @Override
+            public boolean verify(String code, String userInputCode) {
+                return Objects.equals(code, userInputCode);
+            }
+        });
+        return captcha;
+    }
+}

--- a/chatgpt-bootstrap/src/main/resources/application-dev.yaml
+++ b/chatgpt-bootstrap/src/main/resources/application-dev.yaml
@@ -49,3 +49,27 @@ chat:
   isShowBalance: ${CHAT_IS_SHOW_BALANCE:false}
   # 是否展示管理端隐藏的消息，默认不展示
   isAdminShowHiddenMessage: ${CHAT_IS_ADMIN_SHOW_HIDDEN_MESSAGE:false}
+
+  # 邮箱验证相关
+email:
+  # SMTP服务器地址
+  host: ${EMAIL_HOST:smtp.163.com}
+  # 服务器一般默认25端口
+  port: ${EMAIL_PORT:994}
+  # 邮箱地址
+  from: ${EMAIL_FROM:stargpt@163.com}
+  # 用户名，发件人前缀
+  user: ${EMAIL_USER:stargpt@163.com}
+  # 如果要授权码，这里就是传授权码
+  pass: ${EMAIL_PASS:QGPFIFYFFRQBGATA}
+  # 是否需要授权，决定是否要设置授权码
+  auth: ${EMAIL_AUTH:true}
+  # 邮箱验证码有效期（单位，分钟）
+  verifyCodeExpireMinutes: ${EMAIL_CODE_EXPIRE_MINUTES:15}
+  # 邮箱验证，跳转地址基础路径（可以携带参数），这里的type无特殊作用，仅用于演示
+  verificationRedirectUrl: ${EMAIL_VERIFY_REDIRECT_URL:https://stargpt.hncboy.com?type=email}
+sa-token:
+  # 前端用户登录，用于加密JWT
+  jwt-secret-key: ${JWT_SECRET:starGPT666}
+  # JWT有效期
+  timeout: ${LOGIN_TIMEOUT_SECONDS:86400}

--- a/chatgpt-bootstrap/src/main/resources/application-prod.yaml
+++ b/chatgpt-bootstrap/src/main/resources/application-prod.yaml
@@ -49,3 +49,27 @@ chat:
   isShowBalance: ${CHAT_IS_SHOW_BALANCE:false}
   # 是否展示管理端隐藏的消息，默认不展示
   isAdminShowHiddenMessage: ${CHAT_IS_ADMIN_SHOW_HIDDEN_MESSAGE:false}
+
+  # 邮箱验证相关
+email:
+  # SMTP服务器地址
+  host: ${EMAIL_HOST:smtp.163.com}
+  # 服务器一般默认25端口
+  port: ${EMAIL_PORT:994}
+  # 邮箱地址
+  from: ${EMAIL_FROM:stargpt@163.com}
+  # 用户名，发件人前缀
+  user: ${EMAIL_USER:stargpt@163.com}
+  # 如果要授权码，这里就是传授权码
+  pass: ${EMAIL_PASS:QGPFIFYFFRQBGATA}
+  # 是否需要授权，决定是否要设置授权码
+  auth: ${EMAIL_AUTH:true}
+  # 邮箱验证码有效期（单位，分钟）
+  verifyCodeExpireMinutes: ${EMAIL_CODE_EXPIRE_MINUTES:15}
+  # 邮箱验证，跳转地址基础路径（可以携带参数），这里的type无特殊作用，仅用于演示
+  verificationRedirectUrl: ${EMAIL_VERIFY_REDIRECT_URL:https://stargpt.hncboy.com?type=email}
+sa-token:
+  # 前端用户登录，用于加密JWT
+  jwt-secret-key: ${JWT_SECRET:starGPT666}
+  # JWT有效期
+  timeout: ${LOGIN_TIMEOUT_SECONDS:86400}

--- a/chatgpt-bootstrap/src/main/resources/db/schema-mysql.sql
+++ b/chatgpt-bootstrap/src/main/resources/db/schema-mysql.sql
@@ -54,3 +54,91 @@ CREATE TABLE IF NOT EXISTS sensitive_word (
     create_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
     update_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='敏感词表';
+
+-- 发送邮箱验证码记录表
+create table email_verify_code
+(
+    id               int auto_increment
+        primary key,
+    to_email_address varchar(64)                        not null comment '验证码接收邮箱地址',
+    verify_code      varchar(32)                        not null comment '验证码',
+    status           tinyint(1)                         not null comment '使用状态，0表示未使用，1表示已使用',
+    verify_ip        char(32)                           not null comment '核销IP，方便识别一些机器人账号',
+    expire_at        datetime                           not null comment '该条验证码何时过期，一般是发送时间+15分钟',
+    biz_type         tinyint                            not null comment '当前邮箱业务',
+    create_time      datetime default CURRENT_TIMESTAMP not null comment '创建时间',
+    update_time      datetime default CURRENT_TIMESTAMP not null on update CURRENT_TIMESTAMP comment '更新时间'
+) ENGINE=InnoDB comment '邮箱验证码核销记录表，记录某个邮箱发送了什么验证码，方便验证' CHARSET=utf8mb4;
+
+-- 前端基础用户表（用户登录相关），目前简单存储了用户的一些个人信息
+create table front_user_base
+(
+    id             int auto_increment
+        primary key,
+    nickname       varchar(16)                        not null comment '用户昵称',
+    description    varchar(64)                        null comment '描述',
+    avatar_version int                                not null comment '头像版本号',
+    last_login_ip  int                                null comment '上一次登录IP地址（整数）',
+    create_time    datetime default CURRENT_TIMESTAMP not null comment '创建时间',
+    update_time    datetime default CURRENT_TIMESTAMP not null on update CURRENT_TIMESTAMP comment '更新时间'
+) ENGINE=InnoDB comment '前端用户基础信息表，记录了用户的个人信息'  CHARSET=utf8mb4;
+
+-- 前端用户绑定表（用户登录相关），该表记录 基础用户 和 登录方式 的绑定关系
+create table front_user_extra_binding
+(
+    id            int auto_increment
+        primary key,
+    binding_type  varchar(16)                        not null comment '绑定类型,qq,wechat,sina,github,email,phone',
+    extra_info_id int                                not null comment '额外信息表ID',
+    base_user_id  int                                not null comment '基础用户表的ID',
+    create_time   datetime default CURRENT_TIMESTAMP not null,
+    update_time   datetime default CURRENT_TIMESTAMP not null on update CURRENT_TIMESTAMP,
+    constraint front_user_extra_binding_pk2
+        unique (binding_type, base_user_id, extra_info_id)
+) ENGINE=InnoDB comment '前端用户绑定表，记录了 基础用户 和 登录方式 的绑定关系' CHARSET=utf8mb4;
+
+-- 前端用户邮箱登录信息表（用户登录相关），该表记录了使用邮箱注册的用户信息
+create table front_user_extra_email
+(
+    id          int auto_increment
+        primary key,
+    username    varchar(64)                        not null comment '邮箱账号',
+    password    varchar(128)                       not null comment '加密后的密码',
+    salt        varchar(16)                        not null comment '加密盐',
+    verified    tinyint  default 0                 not null comment '是否验证过',
+    create_time datetime default CURRENT_TIMESTAMP not null comment '创建时间',
+    update_time datetime default CURRENT_TIMESTAMP not null on update CURRENT_TIMESTAMP comment '更新时间',
+    constraint front_user_extra_email_pk2
+        unique (username)
+) ENGINE=InnoDB comment '前端用户邮箱登录，记录了使用邮箱注册的用户信息' CHARSET=utf8mb4;
+
+-- 系统表，记录邮件发送日志，目前仅审计用途
+create table sys_email_send_log
+(
+    id                   bigint auto_increment
+        primary key,
+    from_email_address   varchar(64)                        not null comment '发件人',
+    to_email_address     varchar(64)                        not null comment '收件人',
+    biz_type             int                                not null comment '业务类型',
+    content              text                               not null comment '发送内容',
+    message_id           varchar(128)                       not null comment '发送后会返回一个messageId',
+    status               tinyint                            not null comment '发送状态，0失败，1成功',
+    message              varchar(128)                       not null comment '发送后的消息，用于记录成功/失败的信息，成功默认为success',
+    create_time          datetime default CURRENT_TIMESTAMP not null comment '创建时间',
+    update_time          datetime default CURRENT_TIMESTAMP not null on update CURRENT_TIMESTAMP,
+    operator_sys_user_id int      default 1                 not null comment '操作人用户ID，预留字段，默认为1'
+)ENGINE=InnoDB comment '邮箱发送日志，用于审计用途' CHARSET=utf8mb4;
+
+-- 系统表，前端用户登录日志
+create table sys_front_user_login_log
+(
+    id                  int auto_increment
+        primary key,
+    base_user_id        int                                not null comment '登录的基础用户ID',
+    login_type          varchar(32)                        not null comment '登录方式（注册方式），邮箱登录，手机登录等等',
+    login_extra_info_id int                                not null comment '登录信息ID与login_type有关联，邮箱登录时关联front_user_extra_email',
+    login_ip            varchar(32)                        not null comment '登录的IP地址',
+    login_status        tinyint(1)                         not null comment '登录状态，1登录成功，0登录失败',
+    message             varchar(64)                        not null comment '结果，如果成功一律success；否则保存错误信息',
+    create_time         datetime default CURRENT_TIMESTAMP not null comment '发生时间'
+)ENGINE=InnoDB comment '前端用户登录日志表' CHARSET=utf8mb4;

--- a/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/controller/FrontUserController.java
+++ b/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/controller/FrontUserController.java
@@ -1,0 +1,97 @@
+package com.hncboy.chatgpt.front.controller;
+
+import cn.dev33.satoken.stp.StpUtil;
+import cn.dev33.satoken.util.SaResult;
+import com.hncboy.chatgpt.base.enums.FrontUserRegisterTypeEnum;
+import com.hncboy.chatgpt.base.handler.response.R;
+import com.hncboy.chatgpt.front.domain.request.LoginFrontUserByEmailRequest;
+import com.hncboy.chatgpt.front.domain.request.RegisterFrontUserForEmailRequest;
+import com.hncboy.chatgpt.base.annotation.FrontSaCheckLogin;
+import com.hncboy.chatgpt.front.domain.vo.LoginInfoVO;
+import com.hncboy.chatgpt.front.domain.vo.RegisterCaptchaVO;
+import com.hncboy.chatgpt.front.service.FrontUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Resource;
+import lombok.AllArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+
+/**
+ * 前端用户控制器
+ *
+ * @author CoDeleven
+ */
+@AllArgsConstructor
+@Tag(name = "用户相关接口")
+@RestController
+@RequestMapping("/user")
+public class FrontUserController {
+
+    @Resource
+    private FrontUserService frontUserService;
+
+    /**
+     * 用户收到邮件后，点击认证链接完成认证
+     *
+     * @param code 认证代码
+     * @return 发送结果
+     */
+    @Operation(summary = "邮件验证回调")
+    @GetMapping("/verifyEmailCode")
+    public R<Boolean> verifyEmailCode(@Parameter(description = "邮箱验证码") @RequestParam("code") String code) {
+        Boolean data = frontUserService.verifyCode(FrontUserRegisterTypeEnum.EMAIL, code);
+        return R.data(data);
+    }
+
+    /**
+     * 注册前端用户邮箱注册
+     *
+     * @param request 注册请求
+     * @return 发送结果
+     */
+    @Operation(summary = "使用邮箱进行注册")
+    @PostMapping("/register/email")
+    public R<Boolean> registerFrontUser(@Validated @RequestBody RegisterFrontUserForEmailRequest request) {
+        return frontUserService.register(request);
+    }
+
+    /**
+     * 获取用户信息
+     *
+     * @return 登录的用户信息
+     */
+    @Operation(summary = "获取前端登录的用户信息")
+    @GetMapping("/info")
+    @FrontSaCheckLogin
+    public R<LoginInfoVO> getUserInfo() {
+        LoginInfoVO userInfo = frontUserService.getLoginUserInfo();
+        System.out.println(StpUtil.getTokenTimeout());
+        return R.data(userInfo);
+    }
+
+    /**
+     * 获取图片验证码
+     *
+     * @return 图片验证码，Base64
+     */
+    @Operation(summary = "获取图片验证码")
+    @GetMapping("/getPicCode")
+    public R<RegisterCaptchaVO> getPictureVerificationCode() {
+        RegisterCaptchaVO captcha = frontUserService.generateCaptcha();
+        return R.data(captcha);
+    }
+
+    /**
+     * 前端用户登录
+     *
+     * @return Sa-Token登录结果
+     */
+    @Operation(summary = "使用邮箱进行登录")
+    @PostMapping("/login/email")
+    public SaResult login(@RequestBody LoginFrontUserByEmailRequest request) {
+        return frontUserService.login(FrontUserRegisterTypeEnum.EMAIL, request.getUsername(), request.getPassword());
+    }
+}

--- a/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/domain/request/LoginFrontUserByEmailRequest.java
+++ b/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/domain/request/LoginFrontUserByEmailRequest.java
@@ -1,0 +1,25 @@
+package com.hncboy.chatgpt.front.domain.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 前端用户登录请求
+ *
+ * @author CoDeleven
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+@Schema(title = "前端用户登录请求")
+public class LoginFrontUserByEmailRequest {
+    @Schema(title = "邮箱地址")
+    private String username;
+
+    @Schema(title = "密码")
+    private String password;
+}

--- a/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/domain/request/RegisterFrontUserForEmailRequest.java
+++ b/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/domain/request/RegisterFrontUserForEmailRequest.java
@@ -1,0 +1,43 @@
+package com.hncboy.chatgpt.front.domain.request;
+
+import com.hncboy.chatgpt.base.enums.FrontUserRegisterTypeEnum;
+import com.hncboy.chatgpt.front.validation.annotation.FrontUserRegisterAvailable;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 前端用户注册请求
+ *
+ * @author CoDeleven
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+@FrontUserRegisterAvailable
+@Schema(title = "前端用户注册请求，适用于邮箱登录登录")
+public class RegisterFrontUserForEmailRequest {
+    @Size(min = 6, max = 64, message = "用户名长度应为6~64个字符")
+    @NotNull
+    @Schema(title = "用户ID，可以为邮箱，可以为手机号")
+    private String identity;
+
+    @Schema(title = "密码信息，邮箱注册时需传入，手机注册时不用传入")
+    @NotNull
+    private String password;
+
+    @Schema(title = "图形验证码会话ID，必传")
+    @NotNull
+    private String picCodeSessionId;
+
+    @Schema(title = "图片验证码，必传")
+    @NotNull
+    private String picVerificationCode;
+
+    private FrontUserRegisterTypeEnum registerType = FrontUserRegisterTypeEnum.EMAIL;
+}

--- a/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/domain/vo/LoginInfoVO.java
+++ b/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/domain/vo/LoginInfoVO.java
@@ -1,0 +1,29 @@
+package com.hncboy.chatgpt.front.domain.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 登录成功返回用户信息
+ *
+ * @author CoDeleven
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@Schema(title = "登录成功后返回前端用户信息")
+public class LoginInfoVO {
+    @Schema(title = "基础用户ID")
+    private Integer baseUserId;
+    @Schema(title = "用户昵称")
+    private String nickname;
+    @Schema(title = "自我介绍")
+    private String description;
+    @Schema(title = "头像地址")
+    private String avatarUrl;
+    // TODO 付费相关内容拓展
+}

--- a/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/domain/vo/RegisterCaptchaVO.java
+++ b/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/domain/vo/RegisterCaptchaVO.java
@@ -1,0 +1,24 @@
+package com.hncboy.chatgpt.front.domain.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 注册验证码DTO
+ *
+ * @author CoDeleven
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+@Schema(title = "每次注册前需要获取图形验证码信息")
+public class RegisterCaptchaVO {
+    @Schema(title = "图形验证码会话ID，注册时需要传过来")
+    private String picCodeSessionId;
+    @Schema(title = "图形验证码Base64")
+    private String picCodeBase64;
+}

--- a/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/service/FrontUserService.java
+++ b/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/service/FrontUserService.java
@@ -1,0 +1,66 @@
+package com.hncboy.chatgpt.front.service;
+
+import cn.dev33.satoken.util.SaResult;
+import com.hncboy.chatgpt.base.enums.FrontUserRegisterTypeEnum;
+import com.hncboy.chatgpt.base.handler.response.R;
+import com.hncboy.chatgpt.front.domain.request.RegisterFrontUserForEmailRequest;
+import com.hncboy.chatgpt.front.domain.vo.LoginInfoVO;
+import com.hncboy.chatgpt.front.domain.vo.RegisterCaptchaVO;
+
+/**
+ * 前端用户服务，提供注册、认证、授权等功能服务
+ *
+ * @author CoDeleven
+ */
+public interface FrontUserService {
+
+    /**
+     * 处理注册请求
+     *
+     * @param request 注册请求
+     * @return 注册结果
+     */
+    R<Boolean> register(RegisterFrontUserForEmailRequest request);
+
+    /**
+     * 验证码验证
+     *
+     * @param frontUserRegisterTypeEnum 注册类型
+     * @param code 验证码，可以是邮箱也可以是手机
+     * @return true验证成功；false验证失败
+     */
+    Boolean verifyCode(FrontUserRegisterTypeEnum frontUserRegisterTypeEnum, String code);
+
+    /**
+     * 执行登录
+     *
+     * @param registerType 注册类型
+     * @param username 登录用户名，可以是邮箱，可以是手机
+     * @param password 登录口令
+     * @return Sa-Token的登录结果
+     */
+    SaResult login(FrontUserRegisterTypeEnum registerType, String username, String password);
+
+    /**
+     * 根据注册类型+其他绑定信息表获取该用户的登录信息
+     *
+     * @param registerType 注册类型
+     * @param extraInfoId 对应注册类型的表ID
+     * @return 登录用户信息
+     */
+    LoginInfoVO getUserInfo(FrontUserRegisterTypeEnum registerType, Integer extraInfoId);
+
+    /**
+     * 根据当前登录的状态获取用户信息
+     *
+     * @return 登录的用户信息
+     */
+    LoginInfoVO getLoginUserInfo();
+
+    /**
+     * 生成基于Base64的图形验证码
+     *
+     * @return Base64图形验证码
+     */
+    RegisterCaptchaVO generateCaptcha();
+}

--- a/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/service/impl/FrontUserServiceImpl.java
+++ b/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/service/impl/FrontUserServiceImpl.java
@@ -1,0 +1,74 @@
+package com.hncboy.chatgpt.front.service.impl;
+
+import cn.dev33.satoken.stp.StpUtil;
+import cn.dev33.satoken.util.SaResult;
+import cn.hutool.core.util.IdUtil;
+import cn.hutool.core.util.NumberUtil;
+import com.hncboy.chatgpt.base.enums.FrontUserRegisterTypeEnum;
+import com.hncboy.chatgpt.base.handler.response.R;
+import com.hncboy.chatgpt.base.util.SimpleCaptchaUtil;
+import com.hncboy.chatgpt.front.domain.request.RegisterFrontUserForEmailRequest;
+import com.hncboy.chatgpt.front.domain.vo.LoginInfoVO;
+import com.hncboy.chatgpt.front.domain.vo.RegisterCaptchaVO;
+import com.hncboy.chatgpt.front.service.FrontUserService;
+import com.hncboy.chatgpt.front.service.strategy.user.RegisterTypeStrategy;
+import org.springframework.stereotype.Service;
+
+import static com.hncboy.chatgpt.base.constant.ApplicationConstant.FRONT_JWT_REGISTER_TYPE_CODE;
+
+/**
+ * 前端用户服务，用于处理注册/登录/获取用户信息等功能
+ *
+ * @author CoDeleven
+ */
+@Service
+public class FrontUserServiceImpl implements FrontUserService {
+
+    @Override
+    public R<Boolean> register(RegisterFrontUserForEmailRequest request) {
+        RegisterTypeStrategy registerStrategy = RegisterTypeStrategy.findStrategyByRegisterType(request.getRegisterType());
+        Boolean register = registerStrategy.register(request);
+        return R.data(register);
+    }
+
+    @Override
+    public Boolean verifyCode(FrontUserRegisterTypeEnum registerType, String code) {
+        RegisterTypeStrategy registerStrategy = RegisterTypeStrategy.findStrategyByRegisterType(registerType);
+        return registerStrategy.checkVerifyCode(null, code);
+    }
+
+    @Override
+    public SaResult login(FrontUserRegisterTypeEnum registerType, String username, String password) {
+        RegisterTypeStrategy strategy = RegisterTypeStrategy.findStrategyByRegisterType(registerType);
+        return strategy.login(username, password);
+    }
+
+    @Override
+    public LoginInfoVO getUserInfo(FrontUserRegisterTypeEnum registerType, Integer extraInfoId) {
+        RegisterTypeStrategy strategy = RegisterTypeStrategy.findStrategyByRegisterType(registerType);
+        return strategy.getLoginUserInfo(extraInfoId);
+    }
+
+    @Override
+    public RegisterCaptchaVO generateCaptcha() {
+        // 创建一个 图形验证码会话ID
+        String picCodeSessionId = IdUtil.fastUUID();
+        // 根据图形验证码会话ID获取一个图形验证码。该方法会建立起 验证码会话ID 和 图形验证码的关系
+        String captchaBase64Image = SimpleCaptchaUtil.getBase64Captcha(picCodeSessionId);
+        // 将验证码会话ID加入到Cookie中
+        return RegisterCaptchaVO.builder()
+                .picCodeSessionId(picCodeSessionId)
+                .picCodeBase64(captchaBase64Image).build();
+    }
+
+    @Override
+    public LoginInfoVO getLoginUserInfo() {
+        // 获取当前登录用户ID，一般是extraInfoId
+        Integer extraInfoId = NumberUtil.parseInt(String.valueOf(StpUtil.getLoginId()));
+        // 从JWT中提取注册类型
+        String registerTypeCode = (String) StpUtil.getExtra(FRONT_JWT_REGISTER_TYPE_CODE);
+        // 根据registerCode获取注册类型
+        FrontUserRegisterTypeEnum registerType = FrontUserRegisterTypeEnum.getByCode(registerTypeCode);
+        return this.getUserInfo(registerType, extraInfoId);
+    }
+}

--- a/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/service/strategy/user/EmailRegisterStrategy.java
+++ b/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/service/strategy/user/EmailRegisterStrategy.java
@@ -1,0 +1,159 @@
+package com.hncboy.chatgpt.front.service.strategy.user;
+
+import cn.dev33.satoken.stp.SaLoginModel;
+import cn.dev33.satoken.stp.StpUtil;
+import cn.dev33.satoken.util.SaResult;
+import cn.hutool.core.util.RandomUtil;
+import cn.hutool.core.util.StrUtil;
+import com.hncboy.chatgpt.base.constant.ApplicationConstant;
+import com.hncboy.chatgpt.base.domain.entity.EmailVerifyCodeDO;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserBaseDO;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserExtraBindingDO;
+import com.hncboy.chatgpt.base.domain.entity.FrontUserExtraEmailDO;
+import com.hncboy.chatgpt.base.enums.FrontUserRegisterTypeEnum;
+import com.hncboy.chatgpt.base.exception.ServiceException;
+import com.hncboy.chatgpt.base.service.*;
+import com.hncboy.chatgpt.base.enums.EmailBizTypeEnum;
+import com.hncboy.chatgpt.front.domain.request.RegisterFrontUserForEmailRequest;
+import com.hncboy.chatgpt.front.domain.vo.LoginInfoVO;
+import jakarta.annotation.Resource;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.Objects;
+
+import static com.hncboy.chatgpt.base.constant.ApplicationConstant.FRONT_JWT_BASE_USER_ID;
+import static com.hncboy.chatgpt.base.constant.ApplicationConstant.FRONT_JWT_USERNAME;
+
+/**
+ * 邮箱注册策略
+ *
+ * @author CoDeleven
+ */
+@Lazy
+@Component("EmailRegisterStrategy")
+public class EmailRegisterStrategy extends RegisterTypeStrategy{
+    @Resource
+    private FrontUserExtraEmailService userExtraEmailService;
+    @Resource
+    private FrontUserBaseService baseUserService;
+    @Resource
+    private EmailVerifyCodeService emailVerifyCodeService;
+    @Resource
+    private FrontUserExtraBindingService bindingService;
+    @Resource
+    private EmailService emailService;
+    @Resource
+    private SysFrontUserLoginLogService loginLogService;
+
+    @Override
+    public boolean identityUsed(String identity) {
+        return userExtraEmailService.isUsed(identity);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    @Override
+    public boolean checkVerifyCode(String identity, String verifyCode) {
+        // 校验邮箱验证码
+        EmailVerifyCodeDO availableVerifyCode = emailVerifyCodeService.findAvailableByVerifyCode(verifyCode);
+        if(Objects.isNull(availableVerifyCode)) {
+            throw new ServiceException("验证码不存在或已过期，请重新发起...");
+        }
+        // 验证通过，生成基础用户信息并做绑定
+        FrontUserBaseDO baseUser = baseUserService.createEmptyBaseUser();
+        // 获取邮箱信息表
+        FrontUserExtraEmailDO emailExtraInfo = userExtraEmailService.getUnverifiedEmailAccount(availableVerifyCode.getToEmailAddress());
+        // 绑定两张表
+        bindingService.bindEmail(baseUser, emailExtraInfo);
+        // 验证完毕
+        emailVerifyCodeService.verifySuccess(availableVerifyCode);
+        return true;
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    @Override
+    public Boolean register(RegisterFrontUserForEmailRequest request) {
+        // 注册前会校验账号信息，到注册时能确保账号都是可以注册的
+
+        // 查找邮箱账号是否存在
+        FrontUserExtraEmailDO existsEmailDO = userExtraEmailService.getUnverifiedEmailAccount(request.getIdentity());
+        String salt = RandomUtil.randomString(6);
+        // 构建新的邮箱信息
+        if(Objects.isNull(existsEmailDO)) {
+            existsEmailDO = FrontUserExtraEmailDO.builder()
+                    .password(this.encryptRawPassword(request.getPassword(), salt))
+                    .salt(salt)
+                    .username(request.getIdentity())
+                    .verified(false)
+                    .createTime(new Date())
+                    .updateTime(new Date())
+                    .build();
+            // 存储邮箱信息
+            userExtraEmailService.save(existsEmailDO);
+        } else {
+            // 在未使用的邮箱基础上更新下密码信息，然后重新投入使用
+            existsEmailDO.setSalt(salt);
+            existsEmailDO.setVerified(false);
+            existsEmailDO.setPassword(this.encryptRawPassword(request.getPassword(), salt));
+            existsEmailDO.setUpdateTime(new Date());
+            // 存储邮箱信息
+            userExtraEmailService.updateById(existsEmailDO);
+        }
+        // 存储验证码记录
+        EmailVerifyCodeDO emailVerifyCodeDO = emailVerifyCodeService.createVerifyCode(EmailBizTypeEnum.REGISTER_VERIFY, request.getIdentity());
+
+        // 发送邮箱验证信息
+        emailService.sendForVerifyCode(request.getIdentity(), emailVerifyCodeDO.getVerifyCode());
+        return true;
+    }
+
+    @Override
+    public LoginInfoVO getLoginUserInfo(Integer extraInfoId) {
+        // 根据注册类型+extraInfoId获取 当前邮箱绑定在了哪个用户上
+        FrontUserExtraBindingDO bindingRelations = bindingService.findBindingRelations(FrontUserRegisterTypeEnum.EMAIL, extraInfoId);
+        if(Objects.isNull(bindingRelations)) {
+            throw new ServiceException(StrUtil.format("注册方式：{} 额外信息ID：{} 绑定关系不存在",
+                    FrontUserRegisterTypeEnum.EMAIL.getDesc(), extraInfoId));
+        }
+        // 根据绑定关系查找基础用户信息
+        FrontUserBaseDO baseUser = baseUserService.findUserInfoById(bindingRelations.getBaseUserId());
+        if(Objects.isNull(baseUser)) {
+            throw new ServiceException(StrUtil.format("基础用户不存在：{}", bindingRelations.getBaseUserId()));
+        }
+        // 封装基础用户信息并返回
+        return LoginInfoVO.builder().baseUserId(baseUser.getId())
+                .description(baseUser.getDescription())
+                .nickname(baseUser.getNickname())
+                .avatarUrl("").build();
+    }
+
+    @Override
+    public SaResult login(String username, String password) {
+        // 验证账号信息
+        FrontUserExtraEmailDO account = userExtraEmailService.getEmailAccount(username);
+        if(Objects.isNull(account)) {
+            return SaResult.error("账号或密码错误");
+        }
+        // 二次加密，验证账号密码
+        String salt = account.getSalt();
+        String afterEncryptedPassword = this.encryptRawPassword(password, salt);
+        if(!Objects.equals(afterEncryptedPassword, account.getPassword())) {
+            loginLogService.loginFailed(FrontUserRegisterTypeEnum.EMAIL, account.getId(), 0, "账号或密码错误");
+            return SaResult.error("账号或密码错误");
+        }
+        // 获取登录用户信息
+        LoginInfoVO loginInfoVO = this.getLoginUserInfo(account.getId());
+
+        // 执行登录
+        StpUtil.login(account.getId(), SaLoginModel.create()
+                .setExtra(FRONT_JWT_USERNAME, account.getUsername())
+                .setExtra(ApplicationConstant.FRONT_JWT_REGISTER_TYPE_CODE, FrontUserRegisterTypeEnum.EMAIL.getCode())
+                .setExtra(FRONT_JWT_BASE_USER_ID, loginInfoVO.getBaseUserId()));
+
+        // 记录登录日志
+        loginLogService.loginSuccess(FrontUserRegisterTypeEnum.EMAIL, account.getId(), loginInfoVO.getBaseUserId());
+        return SaResult.ok().setData(loginInfoVO);
+    }
+}

--- a/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/service/strategy/user/RegisterTypeStrategy.java
+++ b/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/service/strategy/user/RegisterTypeStrategy.java
@@ -1,0 +1,86 @@
+package com.hncboy.chatgpt.front.service.strategy.user;
+
+import cn.dev33.satoken.util.SaResult;
+import cn.hutool.crypto.digest.MD5;
+import cn.hutool.extra.spring.SpringUtil;
+import com.hncboy.chatgpt.base.enums.FrontUserRegisterTypeEnum;
+import com.hncboy.chatgpt.base.exception.ServiceException;
+import com.hncboy.chatgpt.front.domain.request.RegisterFrontUserForEmailRequest;
+import com.hncboy.chatgpt.front.domain.vo.LoginInfoVO;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * 注册类型策略抽象类
+ *
+ * @author CoDeleven
+ */
+public abstract class RegisterTypeStrategy {
+    // 后续其他登录方式往这里添加
+    private final static RegisterTypeStrategy EMAIL_STRATEGY = SpringUtil.getBean("EmailRegisterStrategy", RegisterTypeStrategy.class);
+
+    /**
+     * 根据注册类型获取逻辑处理策略
+     *
+     * @param registerType 注册类型
+     * @return 策略
+     */
+    public static RegisterTypeStrategy findStrategyByRegisterType(FrontUserRegisterTypeEnum registerType) {
+        switch (registerType) {
+            case EMAIL: return EMAIL_STRATEGY;
+            case PHONE:
+        }
+        throw new ServiceException("暂不支持" + registerType.getDesc() + "注册逻辑");
+    }
+
+    /**
+     * 给原生密码+盐进行加密
+     *
+     * @return 返回加密后16进制的字符串
+     */
+    protected String encryptRawPassword(String rawPassword, String salt) {
+        return MD5.create().digestHex16(rawPassword + salt, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * 验证是否是有效的注册载体
+     *
+     * @param identity 邮箱注册就是邮箱，手机号注册就是手机
+     * @return true有效，false无效
+     */
+    public abstract boolean identityUsed(String identity);
+
+    /**
+     * 执行注册逻辑
+     *
+     * @param request 注册请求
+     * @return 是否处理成功
+     */
+    public abstract Boolean register(RegisterFrontUserForEmailRequest request);
+
+    /**
+     * 校验验证码是否通过
+     *
+     * @param identity 用户账号，可能为空。一般邮箱情况下会为空，手机情况下不为空
+     * @param verifyCode 邮箱策略时为邮箱验证码；手机策略时为手机短信验证码
+     * @return true校验通过；false校验失败
+     */
+    public abstract boolean checkVerifyCode(String identity, String verifyCode);
+
+    /**
+     * 登录
+     *
+     * @param username 用户名，可以是手机号、邮箱
+     * @param password 短信验证码/密码
+     * @return 登录成功后的信息
+     */
+    public abstract SaResult login(String username, String password);
+
+    /**
+     * 获取登录用户信息
+     *
+     * @param extraInfoId 绑定信息表ID
+     * @return 登录用户信息
+     */
+    public abstract LoginInfoVO getLoginUserInfo(Integer extraInfoId);
+}

--- a/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/validation/annotation/FrontUserRegisterAvailable.java
+++ b/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/validation/annotation/FrontUserRegisterAvailable.java
@@ -1,0 +1,26 @@
+package com.hncboy.chatgpt.front.validation.annotation;
+
+import com.hncboy.chatgpt.front.validation.impl.FrontUserRegisterAvailableValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 前端用户注册校验器
+ *
+ * @author CoDeleven
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = FrontUserRegisterAvailableValidator.class)
+public @interface FrontUserRegisterAvailable {
+    String message() default "校验不通过";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/validation/impl/FrontUserRegisterAvailableValidator.java
+++ b/chatgpt-front/src/main/java/com/hncboy/chatgpt/front/validation/impl/FrontUserRegisterAvailableValidator.java
@@ -1,0 +1,130 @@
+package com.hncboy.chatgpt.front.validation.impl;
+
+import cn.hutool.core.lang.Validator;
+import cn.hutool.core.util.PhoneUtil;
+import cn.hutool.core.util.StrUtil;
+import com.hncboy.chatgpt.base.enums.FrontUserRegisterTypeEnum;
+import com.hncboy.chatgpt.base.util.SimpleCaptchaUtil;
+import com.hncboy.chatgpt.front.domain.request.RegisterFrontUserForEmailRequest;
+import com.hncboy.chatgpt.front.service.strategy.user.RegisterTypeStrategy;
+import com.hncboy.chatgpt.front.validation.annotation.FrontUserRegisterAvailable;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Objects;
+
+/**
+ * 前端用户注册有效性校验器
+ *
+ * @author CoDeleven
+ */
+@Slf4j
+public class FrontUserRegisterAvailableValidator implements ConstraintValidator<FrontUserRegisterAvailable, RegisterFrontUserForEmailRequest> {
+    @Override
+    public void initialize(FrontUserRegisterAvailable constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(RegisterFrontUserForEmailRequest registerRequest, ConstraintValidatorContext context) {
+        // 可能是手机，也可能是邮箱，取决于 RegisterFrontUserRequest#registerType
+        String identity = registerRequest.getIdentity();
+        FrontUserRegisterTypeEnum registerType = registerRequest.getRegisterType();
+        boolean isValid = isUnregisteredIdentity(registerType, identity, context);
+        if(!isValid) {
+            log.info("注册 {} 注册账号：{} 已使用，校验不通过", registerType.getDesc(), registerRequest.getIdentity());
+            return false;
+        }
+        // 如果注册类型=手机，验证手机号是否有效；如果注册类型=邮箱，验证邮箱是否有效
+        isValid = isValidFormatIdentity(registerType, identity, context);
+        if(!isValid) {
+            log.info("注册 {} 注册账号：{} 格式不正确，校验不通过", registerType.getDesc(), registerRequest.getIdentity());
+            return false;
+        }
+        if(StrUtil.isBlank(registerRequest.getPicCodeSessionId())) {
+            log.info("注册 {} 注册账号：{} 图形验证码会话不存在，校验不通过", registerType.getDesc(), registerRequest.getIdentity());
+            return false;
+        }
+        isValid = SimpleCaptchaUtil.verifyCaptcha(registerRequest.getPicCodeSessionId(), registerRequest.getPicVerificationCode());
+        if(!isValid) {
+            log.info("注册 {} 注册账号：{} 验证码错误，校验不通过", registerType.getDesc(), registerRequest.getIdentity());
+            return false;
+        }
+        // 手机注册时，检验短信验证码
+        // TODO 看看怎么校验一下邮箱、手机
+//        isValid = checkVerifyCode(registerType, identity, registerRequest.getSmsVerificationCode(), context);
+//        if(!isValid) {
+//            log.info("注册 {} 注册账号：{} 格式不正确，校验不通过", registerType.getDesc(), registerRequest.getIdentity());
+//            return false;
+//        }
+        return true;
+    }
+
+    /**
+     * 校验验证码，如果是邮箱校验邮箱验证码；如果是手机校验手机验证码
+     *
+     * @param registerType 注册类型
+     * @param identity  账号，邮箱账号/手机号码
+     * @param verifyCode 验证码，邮箱验证码/手机短信验证码
+     * @return true校验通过；false校验失败
+     */
+    private boolean checkVerifyCode(FrontUserRegisterTypeEnum registerType,
+                                    String identity, String verifyCode, ConstraintValidatorContext context) {
+        // 检测短信验证码
+        if(registerType == FrontUserRegisterTypeEnum.PHONE) {
+            RegisterTypeStrategy registerStrategy = RegisterTypeStrategy.findStrategyByRegisterType(registerType);
+            if(!registerStrategy.checkVerifyCode(identity, verifyCode)) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate("手机短信验证码错误")
+                        .addConstraintViolation();
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * 验证注册载体是否使用过
+     *
+     * @return true未使用过，校验通过；false已注册过，校验不通过
+     */
+    private boolean isUnregisteredIdentity(FrontUserRegisterTypeEnum registerType, String identity,
+                                           ConstraintValidatorContext context) {
+        // 检测账号是否已注册
+        RegisterTypeStrategy registerStrategy = RegisterTypeStrategy.findStrategyByRegisterType(registerType);
+        // 主要检测手机号/邮箱 是否已使用，
+        boolean isUsed = registerStrategy.identityUsed(identity);
+        if(isUsed) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(registerType.getDesc() + "已使用")
+                    .addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * 验证注册载体是否符合格式
+     *
+     * @param registerType 注册类型
+     * @param identity 注册载体标识，全局唯一
+     * @return true校验通过；false校验不通过
+     */
+    private boolean isValidFormatIdentity(FrontUserRegisterTypeEnum registerType, String identity, ConstraintValidatorContext context) {
+        boolean isValid = true;
+        // 验证邮箱/手机格式是否正确
+        if(registerType == FrontUserRegisterTypeEnum.EMAIL && !Validator.isEmail(identity)) {
+            isValid = false;
+        } else if (registerType == FrontUserRegisterTypeEnum.PHONE && !PhoneUtil.isPhone(identity)) {
+            isValid = false;
+        }
+        // 自定义验证结果信息
+        if(!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(registerType.getDesc() + "格式不正确")
+                    .addConstraintViolation();
+        }
+        return isValid;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
         <dependency>
@@ -116,11 +120,27 @@
             <artifactId>sa-token-spring-boot3-starter</artifactId>
             <version>${satoken.version}</version>
         </dependency>
+        <dependency>
+            <groupId>cn.dev33</groupId>
+            <artifactId>sa-token-jwt</artifactId>
+            <version>${satoken.version}</version>
+        </dependency>
         <!-- guava -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+        </dependency>
+        <!-- email -->
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>javax.mail-api</artifactId>
+            <version>1.6.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>javax.mail</artifactId>
+            <version>1.6.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
增加前端用户登录功能
* 设计目标：兼容邮箱、手机、三方登录（QQ、微信等）
* 设计思路：将用户信息和登录方式拆分，使用中间表绑定
* 完成情况：图形验证码校验；邮箱注册；基础用户信息获取；邮件发送日志记录；用户登录日志记录
